### PR TITLE
Make influxdb org_id and bucket configurable

### DIFF
--- a/server/influxdb.go
+++ b/server/influxdb.go
@@ -7,23 +7,23 @@ import (
 )
 
 const (
-	org                      = "trento"
-	bucket                   = "telemetry"
 	hostTelemetryMeasurement = "host_telemetry"
 )
 
 type InfluxDB struct {
-	url   string
-	token string
+	url    string
+	token  string
+	org    string
+	bucket string
 }
 
-func NewInfluxDB(url string, token string) *InfluxDB {
-	return &InfluxDB{url: url, token: token}
+func NewInfluxDB(url string, token string, org string, bucket string) *InfluxDB {
+	return &InfluxDB{url: url, token: token, org: org, bucket: bucket}
 }
 
 func (i *InfluxDB) StoreHostTelemetry(h *HostTelemetry) error {
 	client := i.getClient()
-	writeAPI := client.WriteAPIBlocking(org, bucket)
+	writeAPI := client.WriteAPIBlocking(i.org, i.bucket)
 	defer client.Close()
 
 	p := influxdb2.NewPointWithMeasurement(hostTelemetryMeasurement).

--- a/server/server.go
+++ b/server/server.go
@@ -65,7 +65,11 @@ func hostTelemetryHandler(adapters ...StorageAdapter) func(w http.ResponseWriter
 }
 
 func HandleRequests() {
-	influxDBAdapter := NewInfluxDB(os.Getenv("TELEMETRY_INFLUXDB_URL"), os.Getenv("TELEMETRY_INFLUXDB_TOKEN"))
+	influxDBAdapter := NewInfluxDB(
+		os.Getenv("TELEMETRY_INFLUXDB_URL"),
+		os.Getenv("TELEMETRY_INFLUXDB_TOKEN"),
+		os.Getenv("TELEMETRY_INFLUXDB_ORG"),
+		os.Getenv("TELEMETRY_INFLUXDB_BUCKET"))
 
 	http.HandleFunc("/api/ping", pingHandler())
 	http.HandleFunc("/api/collect/hosts", hostTelemetryHandler(influxDBAdapter))


### PR DESCRIPTION
Make the influxdb `org_id` and `bucket` configurable.

This is just needed to unblock the deployment part. It is obvious that it needs more work to include cmd flags and better configuration, but by now it lets me move forward.