### PR TITLE
Telemetry service deployment on AWS ECS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /telemetry
+**/.terraform
+**/terraform.tfstate*
+**/.terraform.tfstate*
+**/terraform*.tfvars

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # Trento Telemetry Service
 
 This repo holds the source code of the service Trento uses to collect telemetry data.
+
+## Deployment
+
+The project offers a terraform deployment option in order to deploy the __Trento Telemetry Service__.
+The deployment project deploys the service on AWS ECS (Elastic Containers Service).
+
+The deployment consists of:
+- VPC networking layer including all the needed resources
+- Amazon load balancer
+- Elastic container service based on Fargate (serverless container service)
+
+### Requirements
+
+- terraform version >=0.13.x installed
+- AWS access and secret keys (with ECS, Load balancer, VPC management, etc IAM rights)
+- Already deployed InfluxDB database. The service url, organization id, bucket name and api token with write/right access to this bucket are needed
+
+## How to deploy
+
+Follow the next steps to deploy the service:
+
+1. Access the `deployment` folder
+2. Create a new `terraform.tfvars` file. Use the [terraform.tfvars.example](deployment/terraform.tfvars.example) as example
+3. Run:
+```
+terraform init
+terraform apply
+```
+4. When the deployment is completed the terraform output shows the `dns_name` which Trento should send the telemetry data

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -1,0 +1,16 @@
+module "telemetry_application" {
+  source      = "./modules/application_ecs"
+
+  name            = var.name
+  region          = var.region
+  aws_access_key  = var.aws_access_key
+  aws_secret_key  = var.aws_secret_key
+  environment     = var.environment
+  container_image = var.container_image
+  container_tag   = var.container_tag
+
+  influxdb_url    = var.influxdb_url
+  influxdb_token  = var.influxdb_token
+  influxdb_org    = var.influxdb_org
+  influxdb_bucket = var.influxdb_bucket
+}

--- a/deployment/modules/application_ecs/main.tf
+++ b/deployment/modules/application_ecs/main.tf
@@ -1,0 +1,259 @@
+provider "aws" {
+  region     = var.region
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}
+
+################################################################################
+# Network
+################################################################################
+
+data "aws_availability_zones" "available" {
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name                 = var.name
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    Name        = "${var.name}-public-subnets-${var.environment}"
+    Environment = var.environment
+  }
+
+  private_subnet_tags = {
+    Name        = "${var.name}-private-subnets-${var.environment}"
+    Environment = var.environment
+  }
+
+  tags = {
+    Name        = "${var.name}-vpc-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+################################################################################
+# Security groups
+################################################################################
+
+resource "aws_security_group" "alb" {
+  name   = "${var.name}-sg-alb-${var.environment}"
+  vpc_id = module.vpc.vpc_id
+
+  ingress {
+    protocol         = "tcp"
+    from_port        = var.load_balancer_port
+    to_port          = var.load_balancer_port
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    protocol         = "-1"
+    from_port        = 0
+    to_port          = 0
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name        = "${var.name}-sg-alb-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_security_group" "ecs_tasks" {
+  name   = "${var.name}-sg-task-${var.environment}"
+  vpc_id = module.vpc.vpc_id
+
+  ingress {
+    protocol         = "tcp"
+    from_port        = var.container_port
+    to_port          = var.container_port
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    protocol         = "-1"
+    from_port        = 0
+    to_port          = 0
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name        = "${var.name}-sg-task-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+################################################################################
+# Load balancer
+################################################################################
+
+resource "aws_lb" "main" {
+  name               = "${var.name}-alb-${var.environment}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = module.vpc.public_subnets
+
+  enable_deletion_protection = false
+}
+
+resource "aws_alb_target_group" "main" {
+  name        = "${var.name}-tg-${var.environment}"
+  port        = var.load_balancer_port
+  protocol    = "HTTP"
+  vpc_id      = module.vpc.vpc_id
+  target_type = "ip"
+
+  health_check {
+   healthy_threshold   = "3"
+   interval            = "30"
+   protocol            = "HTTP"
+   matcher             = "200"
+   timeout             = "3"
+   path                = "/api/ping"
+   unhealthy_threshold = "2"
+  }
+}
+
+# TODO: Accept only TLS secured data
+resource "aws_alb_listener" "http" {
+    load_balancer_arn = aws_lb.main.id
+    port              = 80
+    protocol          = "HTTP"
+
+    default_action {
+      target_group_arn = aws_alb_target_group.main.id
+      type             = "forward"
+    }
+}
+
+################################################################################
+# ECS
+################################################################################
+
+resource "aws_ecs_cluster" "main" {
+  name = "${var.name}-cluster-${var.environment}"
+
+  tags = {
+    Name        = "${var.name}-sg-task-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.name}-ecs-task-role"
+
+  assume_role_policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+       "Service": "ecs-tasks.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
+ ]
+}
+EOF
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "${var.name}-ecs-task-execution-role"
+
+  assume_role_policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+       "Service": "ecs-tasks.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
+ ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-policy-attachment" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_ecs_task_definition" "main" {
+  family                   = "${var.name}-task-${var.environment}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+
+  container_definitions    = jsonencode([{
+   name        = "${var.name}-container-${var.environment}"
+   image       = "${var.container_image}:${var.container_tag}"
+   essential   = true
+   portMappings = [{
+     protocol      = "tcp"
+     containerPort = var.container_port
+     hostPort      = var.container_port
+   }]
+   environment: [
+    { name = "TELEMETRY_INFLUXDB_URL", value = var.influxdb_url },
+    { name = "TELEMETRY_INFLUXDB_TOKEN", value = var.influxdb_token }, # TODO: This should go as secret
+    { name = "TELEMETRY_INFLUXDB_ORG", value = var.influxdb_org },
+    { name = "TELEMETRY_INFLUXDB_BUCKET", value = var.influxdb_bucket }
+   ]
+  }])
+
+  tags = {
+    Name        = "${var.name}-sg-task-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_ecs_service" "main" {
+  name            = "${var.name}-ecs-service-${var.environment}"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.main.arn
+
+  desired_count                      = 2
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+  launch_type                        = "FARGATE"
+  scheduling_strategy                = "REPLICA"
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    subnets          = module.vpc.private_subnets
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.main.id
+    container_name   = "${var.name}-container-${var.environment}"
+    container_port   = var.container_port
+  }
+
+  lifecycle {
+   ignore_changes = [task_definition, desired_count]
+ }
+}

--- a/deployment/modules/application_ecs/main.tf
+++ b/deployment/modules/application_ecs/main.tf
@@ -198,6 +198,15 @@ resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-policy-attach
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+resource "aws_cloudwatch_log_group" "main" {
+  name = "/ecs/${var.name}-task-${var.environment}"
+
+  tags = {
+    Name        = "${var.name}-task-${var.environment}"
+    Environment = var.environment
+  }
+}
+
 resource "aws_ecs_task_definition" "main" {
   family                   = "${var.name}-task-${var.environment}"
   network_mode             = "awsvpc"
@@ -222,6 +231,14 @@ resource "aws_ecs_task_definition" "main" {
     { name = "TELEMETRY_INFLUXDB_ORG", value = var.influxdb_org },
     { name = "TELEMETRY_INFLUXDB_BUCKET", value = var.influxdb_bucket }
    ]
+   logConfiguration = {
+     logDriver = "awslogs"
+     options = {
+       awslogs-group         = aws_cloudwatch_log_group.main.name
+       awslogs-stream-prefix = "ecs"
+       awslogs-region        = var.region
+     }
+   }
   }])
 
   tags = {

--- a/deployment/modules/application_ecs/outputs.tf
+++ b/deployment/modules/application_ecs/outputs.tf
@@ -1,0 +1,3 @@
+output "dns_name" {
+  value = aws_lb.main.dns_name
+}

--- a/deployment/modules/application_ecs/variables.tf
+++ b/deployment/modules/application_ecs/variables.tf
@@ -1,0 +1,73 @@
+# Influxdb variables
+
+variable "influxdb_url" {
+  type        = string
+  description = "Influxdb service url"
+}
+
+variable "influxdb_token" {
+  type        = string
+  description = "Influxdb API token"
+}
+
+variable "influxdb_org" {
+  type        = string
+  description = "The organization id of the deployed Influxdb"
+}
+
+variable "influxdb_bucket" {
+  type        = string
+  description = "Created Influxdb bucket name. This bucket will have write/read authorizations through an API token"
+}
+
+# ECS variables
+
+variable "aws_access_key" {
+  type = string
+}
+
+variable "aws_secret_key" {
+  type = string
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to deploy the ECS cluster and resources"
+  default     = "eu-west-2"
+}
+
+variable "name" {
+  type        = string
+  description = "Given prefix name of the deployed resources"
+  default     = "trento"
+}
+
+variable "environment" {
+  type        = string
+  description = "Given environment name to group the resources names"
+  default     = "default"
+}
+
+variable "container_image" {
+  type        = string
+  description = "Deployed container name"
+  default     = "ghcr.io/trento-project/trento-telemetry"
+}
+
+variable "container_tag" {
+  type        = string
+  description = "Deployed container tag"
+  default     = "latest"
+}
+
+variable "container_port" {
+  type        = number
+  description = "Port where the telemetry service is listening within the container"
+  default     = 10000
+}
+
+variable "load_balancer_port" {
+  type        = number
+  description = "Port where the load balancer is listening"
+  default     = 80
+}

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -1,0 +1,3 @@
+output "dns_name" {
+  value = module.telemetry_application.dns_name
+}

--- a/deployment/terraform.tfvars.example
+++ b/deployment/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# Influxdb data
+influxdb_url = "https://influxdata.com"
+influxdb_token = "1234567890abcdef=="
+influxdb_org = "your-org"
+influxdb_bucket = "trento-telemetry"
+
+# ECS deployment data
+name = "trento-telemetry"
+region = "eu-west-2"
+aws_access_key = "1234567890abcdef"
+aws_secret_key = "your-secret"

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -1,0 +1,74 @@
+# Influxdb variables
+
+variable "influxdb_url" {
+  type        = string
+  description = "Influxdb database url (it doesn't containt the organization id). Example: https://influxdb.com"
+}
+
+variable "influxdb_token" {
+  type        = string
+  description = "Influxdb connection token. It must have bucket and api creation authorizations"
+}
+
+variable "influxdb_org" {
+  type        = string
+  description = "The organization id of the deployed Influxdb"
+}
+
+variable "influxdb_bucket" {
+  type        = string
+  description = "Created Influxdb bucket name. This bucket will have write/read authorizations through an API token"
+  default     = "trento-telemetry"
+}
+
+# ECS variables
+
+variable "aws_access_key" {
+  type = string
+}
+
+variable "aws_secret_key" {
+  type = string
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to deploy the ECS cluster and resources"
+  default     = "eu-west-2"
+}
+
+variable "name" {
+  type        = string
+  description = "Given prefix name of the deployed resources"
+  default     = "trento"
+}
+
+variable "environment" {
+  type        = string
+  description = "Given environment name to group the resources names"
+  default     = "default"
+}
+
+variable "container_image" {
+  type        = string
+  description = "Deployed container name"
+  default     = "ghcr.io/trento-project/trento-telemetry"
+}
+
+variable "container_tag" {
+  type        = string
+  description = "Deployed container tag"
+  default     = "latest"
+}
+
+variable "container_port" {
+  type        = number
+  description = "Port where the telemetry service is listening within the container"
+  default     = 10000
+}
+
+variable "load_balancer_port" {
+  type        = number
+  description = "Port where the load balancer is listening"
+  default     = 80
+}


### PR DESCRIPTION
1st version of deployment of the Trento telemetry service on AWS, using:
- ECS (Elastic container service)
- Fargate (serverless service)

The deployment is minimalist by now, only deploying the minimal set of needed resources. It basically deploys the docker container defined in the project Dockerfile in the AWS ECS service together with a load balancer.

Implemented in terraform.

Most of the info should be in the new chapter in the README file.

**This is just a 1st version. There are many possible improvements**