### PR TITLE
Save host telemetries as batch

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,16 @@
 package main
 
 import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
 	server "github.com/trento-project/telemetry/server"
 )
 
 func main() {
+	if os.Getenv("TELEMETRY_DEBUG") == "true" {
+		log.SetLevel(log.DebugLevel)
+	}
+
 	server.HandleRequests()
 }

--- a/server/influxdb.go
+++ b/server/influxdb.go
@@ -30,6 +30,7 @@ func (i *InfluxDB) StoreHostTelemetry(h []*HostTelemetry) error {
 	var err error
 	for _, t := range h {
 		p := influxdb2.NewPointWithMeasurement(hostTelemetryMeasurement).
+			AddTag("installation_id", t.InstallationID).
 			AddTag("agent_id", t.AgentID).
 			AddField("sles_version", t.SLESVersion).
 			AddField("cpu_count", t.CPUCount).

--- a/server/server.go
+++ b/server/server.go
@@ -16,13 +16,14 @@ type StorageAdapter interface {
 }
 
 type HostTelemetry struct {
-	AgentID       string    `json:"agent_id"`
-	SLESVersion   string    `json:"sles_version"`
-	CPUCount      int       `json:"cpu_count"`
-	SocketCount   int       `json:"socket_count"`
-	TotalMemoryMB int       `json:"total_memory_mb"`
-	CloudProvider string    `json:"cloud_provider"`
-	Time          time.Time `json:"time"`
+	InstallationID string    `json:"installation_id"`
+	AgentID        string    `json:"agent_id"`
+	SLESVersion    string    `json:"sles_version"`
+	CPUCount       int       `json:"cpu_count"`
+	SocketCount    int       `json:"socket_count"`
+	TotalMemoryMB  int       `json:"total_memory_mb"`
+	CloudProvider  string    `json:"cloud_provider"`
+	Time           time.Time `json:"time"`
 }
 
 func pingHandler() func(w http.ResponseWriter, r *http.Request) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -45,22 +45,24 @@ func TestHostTelemetryHandler(t *testing.T) {
 
 	body, _ := json.Marshal([]*HostTelemetry{
 		{
-			AgentID:       "agent_id",
-			SLESVersion:   "15.2",
-			CPUCount:      16,
-			SocketCount:   32,
-			TotalMemoryMB: 32000,
-			CloudProvider: "azure",
-			Time:          time.Now(),
+			InstallationID: "uuid1",
+			AgentID:        "agent_id",
+			SLESVersion:    "15.2",
+			CPUCount:       16,
+			SocketCount:    32,
+			TotalMemoryMB:  32000,
+			CloudProvider:  "azure",
+			Time:           time.Now(),
 		},
 		{
-			AgentID:       "agent_id",
-			SLESVersion:   "15.2",
-			CPUCount:      16,
-			SocketCount:   16,
-			TotalMemoryMB: 32000,
-			CloudProvider: "azure",
-			Time:          time.Now(),
+			InstallationID: "uuid2",
+			AgentID:        "agent_id",
+			SLESVersion:    "15.2",
+			CPUCount:       16,
+			SocketCount:    16,
+			TotalMemoryMB:  32000,
+			CloudProvider:  "azure",
+			Time:           time.Now(),
 		},
 	})
 	req, err := http.NewRequest("POST", "/api/collect/hosts", bytes.NewBuffer(body))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -43,14 +43,25 @@ func TestHostTelemetryHandler(t *testing.T) {
 	storageAdapterMock := new(MockStorageAdapter)
 	storageAdapterMock.On("StoreHostTelemetry", mock.Anything).Return(nil)
 
-	body, _ := json.Marshal(&HostTelemetry{
-		AgentID:       "agent_id",
-		SLESVersion:   "15.2",
-		CPUCount:      16,
-		SocketCount:   32,
-		TotalMemoryMB: 32000,
-		CloudProvider: "azure",
-		Time:          time.Now(),
+	body, _ := json.Marshal([]*HostTelemetry{
+		{
+			AgentID:       "agent_id",
+			SLESVersion:   "15.2",
+			CPUCount:      16,
+			SocketCount:   32,
+			TotalMemoryMB: 32000,
+			CloudProvider: "azure",
+			Time:          time.Now(),
+		},
+		{
+			AgentID:       "agent_id",
+			SLESVersion:   "15.2",
+			CPUCount:      16,
+			SocketCount:   16,
+			TotalMemoryMB: 32000,
+			CloudProvider: "azure",
+			Time:          time.Now(),
+		},
 	})
 	req, err := http.NewRequest("POST", "/api/collect/hosts", bytes.NewBuffer(body))
 	if err != nil {

--- a/server/storage_adapter_mock.go
+++ b/server/storage_adapter_mock.go
@@ -10,11 +10,11 @@ type MockStorageAdapter struct {
 }
 
 // StoreHostTelemetry provides a mock function with given fields: _a0
-func (_m *MockStorageAdapter) StoreHostTelemetry(_a0 *HostTelemetry) error {
+func (_m *MockStorageAdapter) StoreHostTelemetry(_a0 []*HostTelemetry) error {
 	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*HostTelemetry) error); ok {
+	if rf, ok := ret.Get(0).(func([]*HostTelemetry) error); ok {
 		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)


### PR DESCRIPTION
This PR changes the host telemetry handler to support batch of host telemetries rather than one at once.
