### PR TITLE
change default internal listening port to 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN make build
 FROM gcr.io/distroless/base:debug AS telemetry
 COPY --from=go-build /build/telemetry /app/telemetry
 LABEL org.opencontainers.image.source="https://github.com/trento-project/telemetry"
-EXPOSE 10000/tcp
+EXPOSE 80/tcp
 ENTRYPOINT ["/app/telemetry"]

--- a/server/server.go
+++ b/server/server.go
@@ -108,5 +108,5 @@ func HandleRequests() {
 	http.HandleFunc("/api/collect/hosts", hostTelemetryHandler(influxDBAdapter, postgresAdapter))
 
 	log.Infof("Starting Trento telemetry server...")
-	log.Fatal(http.ListenAndServe(":10000", nil))
+	log.Fatal(http.ListenAndServe(":80", nil))
 }


### PR DESCRIPTION
There is no need to diverge from standard ports.

Terraform configuration update will follow with included TLS LB termination.