### PR TITLE
Add SNS mail notification in service state changes

### DIFF
--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -40,3 +40,12 @@ module "telemetry_application" {
   database_password = module.database.database_password
   database_name     = module.database.database_name
 }
+
+module "mail_notification" {
+  source      = "./modules/mail_notification"
+
+  name                                = var.name
+  environment                         = var.environment
+  sns_subscription_email_address_list = var.sns_subscription_email_address_list
+  ecs_arn                             = module.telemetry_application.ecs_arn
+}

--- a/deployment/modules/application_ecs/outputs.tf
+++ b/deployment/modules/application_ecs/outputs.tf
@@ -1,3 +1,7 @@
 output "dns_name" {
   value = aws_lb.main.dns_name
 }
+
+output "ecs_arn" {
+  value = aws_ecs_cluster.main.arn
+}

--- a/deployment/modules/mail_notification/main.tf
+++ b/deployment/modules/mail_notification/main.tf
@@ -1,0 +1,50 @@
+resource "aws_sns_topic" "state_updates" {
+  name       = "${var.name}-sns-topic-${var.environment}"
+
+  tags = {
+    Name        = "${var.name}-task-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_sns_topic_subscription" "state_updates_subscription" {
+  count     = length(var.sns_subscription_email_address_list)
+  topic_arn = aws_sns_topic.state_updates.id
+  protocol  = "email"
+  endpoint  = element(var.sns_subscription_email_address_list, count.index)
+}
+
+resource "aws_cloudwatch_event_rule" "state_updates_watch" {
+  name        = "${var.name}-cloudwatch-rule-${var.environment}"
+  description = "Notify Telemetry service tasks state changes"
+
+  event_pattern = <<EOF
+  {
+    "source": [
+      "aws.ecs"
+    ],
+    "detail-type": [
+      "ECS Task State Change"
+    ],
+    "detail": {
+      "clusterArn": [
+        "${var.ecs_arn}"
+      ]
+    }
+  }
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "sns" {
+  rule      = aws_cloudwatch_event_rule.state_updates_watch.name
+  arn       = aws_sns_topic.state_updates.id
+
+  input_transformer {
+    input_paths = {
+      stoppedReason = "$.detail.stoppedReason",
+      lastStatus    = "$.detail.lastStatus",
+      group         = "$.detail.group",
+    }
+    input_template = "\"The container <group> in ${var.name}/${var.environment} got <lastStatus> due to <stoppedReason>\""
+  }
+}

--- a/deployment/modules/mail_notification/variables.tf
+++ b/deployment/modules/mail_notification/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  type        = string
+  description = "Given prefix name of the deployed resources"
+}
+
+variable "environment" {
+  type        = string
+  description = "Given environment name to group the resources names"
+}
+
+variable "sns_subscription_email_address_list" {
+  type        = list(string)
+  description = "List of email addresses to notify service state changes"
+}
+
+variable "ecs_arn" {
+  type        = string
+  description = "Created ECS cluster arn"
+}

--- a/deployment/terraform.tfvars.example
+++ b/deployment/terraform.tfvars.example
@@ -9,3 +9,4 @@ lb_certificate_arn = ""
 # name = "trento-telemetry"
 # region = "eu-central-1"
 # environment = "default"
+sns_subscription_email_address_list = ["trento@trento.com", "other@trento.com"]

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -65,3 +65,8 @@ variable "dns_cname" {
   description = "The name of the CNAME record to add"
   default     = "telemetry"
 }
+
+variable "sns_subscription_email_address_list" {
+  type        = list(string)
+  description = "List of email addresses to notify service state changes"
+}


### PR DESCRIPTION
Add SNS mail notifications deployment in terraform.
This creates automatic mail notifications en each task state change (container state changed). It is based in native cloudwatch event system.

In order to use it, use the new variable `sns_subscription_email_address_list`. Example:
```
sns_subscription_email_address_list = ["trento@trento.com", "other@trento.com"]
```