### PR TITLE
Telemetry grafana dashboard

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -74,9 +74,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - name: telemetry
+            dockerfile: Dockerfile
+          - name: telemetry-grafana
+            dockerfile: Dockerfile.Grafana
     env:
       REGISTRY: ghcr.io
-      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/telemetry
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}
       IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
     steps:
       - uses: actions/checkout@v2
@@ -98,6 +105,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ./${{ matrix.dockerfile }}
           push: true
           tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.Grafana
+++ b/Dockerfile.Grafana
@@ -1,0 +1,3 @@
+FROM grafana/grafana:8.2.6
+
+ADD grafana/provisioning /etc/grafana/provisioning

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Follow the next steps to deploy the service:
     ```
 7. When the deployment is completed the terraform output shows the `url` which Trento should send the telemetry data
 
+## Grafana
+
+The AWS deployment with terraform/docker-compose deployment offers a Grafana instance to visualize the collected telemetry metrics.
+
+In order to access the dashboards:
+- docker-compose: Grafana is available in the port 3000
+- AWS: Grafana is available in the port configured by the `grafana_port` variable (3000 by default) in the same telemetry service URL
+
 ## Development
 
 ### Requirements

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -39,7 +39,10 @@ module "telemetry_application" {
   database_user     = module.database.database_user
   database_password = module.database.database_password
   database_name     = module.database.database_name
-}
+
+  grafana_port            = var.grafana_port
+  grafana_container_image = var.grafana_container_image
+}  
 
 module "mail_notification" {
   source      = "./modules/mail_notification"

--- a/deployment/modules/application_ecs/variables.tf
+++ b/deployment/modules/application_ecs/variables.tf
@@ -47,6 +47,18 @@ variable "database_name" {
   description = "PostgreSQL database name"
 }
 
+# Grafana
+
+variable "grafana_port" {
+  type        = number
+  description = "Grafana instance public port"
+}
+
+variable "grafana_container_image" {
+  type        = string
+  description = "Deployed container name"
+}
+
 # ECS variables
 
 variable "region" {

--- a/deployment/modules/database/main.tf
+++ b/deployment/modules/database/main.tf
@@ -31,6 +31,7 @@ resource "aws_security_group" "database" {
 
 module "database" {
   source = "terraform-aws-modules/rds/aws"
+  version = "3.4.2"
 
   identifier = "${var.name}-database-${var.environment}"
 
@@ -39,7 +40,7 @@ module "database" {
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
   engine               = "postgres"
-  engine_version       = "11.10"
+  engine_version       = "11.13"
   family               = "postgres11" # DB parameter group
   major_engine_version = "11"         # DB option group
   instance_class       = "db.t3.large"

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -11,5 +11,6 @@ output "database_address" {
 }
 
 output "database_password" {
-  value = module.database.database_password
+  value     = module.database.database_password
+  sensitive = true
 }

--- a/deployment/provider.tf
+++ b/deployment/provider.tf
@@ -1,13 +1,14 @@
 terraform {
+  required_version = ">= 1.1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 4.0"
     }
   }
   backend "s3" {
-    bucket = "trento-telemetry-terraform-backend"
-    key    = "trento-telemetry"
+   bucket = "trento-telemetry-terraform-backend"
+   key    = "trento-telemetry"
   }
 }
 

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -29,6 +29,20 @@ variable "influxdb_bucket" {
   default     = "trento-telemetry"
 }
 
+# Grafana
+
+variable "grafana_port" {
+  type        = number
+  description = "Grafana instance public port"
+  default     = 3000
+}
+
+variable "grafana_container_image" {
+  type        = string
+  description = "Deployed container name"
+  default     = "ghcr.io/trento-project/telemetry-grafana:rolling"
+}
+
 # AWS variables
 
 variable "name" {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,25 @@ services:
         published: 5432
         protocol: tcp
 
+  grafana:
+    build:
+      context: .
+      dockerfile: Dockerfile.Grafana
+    env_file:
+      - .env
+    environment:
+      TELEMETRY_INFLUXDB_URL: ${TELEMETRY_INFLUXDB_URL:-http://influx:8086}
+      TELEMETRY_INFLUXDB_ORG: ${TELEMETRY_INFLUXDB_ORG:-suse}
+      TELEMETRY_INFLUXDB_TOKEN: ${TELEMETRY_INFLUXDB_TOKEN:-telemetry-token}
+      TELEMETRY_INFLUXDB_BUCKET: ${TELEMETRY_INFLUXDB_BUCKET:-telemetry}
+    ports:
+      - target: 3000
+        published: 3000
+        protocol: tcp
+    volumes:
+      - grafana_data:/var/lib/grafana:rw
+
 volumes:
   influx_data:
   db_data:
+  grafana_data:

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+- name: Trento telemetry
+  org_id: 1
+  folder: ''
+  type: 'file'
+  disableDeletion: false
+  editable: true
+  updateIntervalSeconds: 5
+  allowUiUpdates: true
+  options:
+    path: /etc/grafana/provisioning/dashboards
+    foldersFromFilesStructure: true

--- a/grafana/provisioning/dashboards/telemetry.json
+++ b/grafana/provisioning/dashboards/telemetry.json
@@ -1,0 +1,503 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": "InfluxDB_v2_Flux",
+      "description": "The number of different Trento installations",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 9,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"host_telemetry\")\n  |> filter(fn: (r) => r[\"_field\"] == \"cloud_provider\")\n  |> group()\n  |> aggregateWindow(every: 1d, fn: unique, column: \"installation_id\")\n  |> aggregateWindow(every: 1d, fn: count)\n  |> rename(columns: {_time: \"time\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Installations number",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "InfluxDB_v2_Flux",
+      "description": "Number of registered agents",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"host_telemetry\")\n  |> filter(fn: (r) => r[\"_field\"] == \"cloud_provider\")\n  |> group()\n  |> aggregateWindow(every: 1d, fn: unique, column: \"agent_id\")\n  |> aggregateWindow(every: 1d, fn: count)\n  |> rename(columns: {_time: \"time\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Agents number",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "InfluxDB_v2_Flux",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#878986",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 6,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "values": []
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"host_telemetry\")\n  |> filter(fn: (r) => r[\"_field\"] == \"cloud_provider\")\n  |> last()\n  |> duplicate(column: \"_value\", as: \"cloud_provider\")\n  |> group(columns: [\"cloud_provider\"])\n  |> count()\n  |> rename(columns: {_value: \"\"})\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Agents number by provider (last values)",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "Value",
+            "renamePattern": "unknown"
+          }
+        }
+      ],
+      "type": "piechart"
+    },
+    {
+      "datasource": "InfluxDB_v2_Flux",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#878986",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"host_telemetry\")\n  |> filter(fn: (r) => r[\"_field\"] == \"sles_version\")\n  |> last()\n  |> duplicate(column: \"_value\", as: \"sles_version\")\n  |> group(columns: [\"sles_version\"])\n  |> count()\n  |> rename(columns: {_value: \"\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Agents by SLES version",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "Value",
+            "renamePattern": "unknown"
+          }
+        }
+      ],
+      "type": "piechart"
+    },
+    {
+      "datasource": "InfluxDB_v2_Flux",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#878986",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": "  from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"host_telemetry\")\n  |> filter(fn: (r) => r[\"_field\"] == \"total_memory_mb\")\n  |> last()\n  |> duplicate(column: \"_value\", as: \"total_memory_mb\")\n  |> group(columns: [\"total_memory_mb\"])\n  |> count()\n  |> rename(columns: {_value: \"Total memory MB\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Agents by Total Memory on MB",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "Total memory MB 0$",
+            "renamePattern": "unknown"
+          }
+        }
+      ],
+      "type": "piechart"
+    },
+    {
+      "datasource": "InfluxDB_v2_Flux",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#878986",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"host_telemetry\")\n  |> filter(fn: (r) => r[\"_field\"] == \"cpu_count\")\n  |> last()\n  |> duplicate(column: \"_value\", as: \"cpu_count\")\n  |> group(columns: [\"cpu_count\"])\n  |> count()\n  |> rename(columns: {_value: \"CPU count\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Agents by CPU count",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "CPU count 0$",
+            "renamePattern": "unknown"
+          }
+        }
+      ],
+      "type": "piechart"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 32,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Trento telemetry",
+  "uid": "cZ4tTs3nk",
+  "version": 17
+}

--- a/grafana/provisioning/datasources/influxdb.yml
+++ b/grafana/provisioning/datasources/influxdb.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB_v2_Flux
+    type: influxdb
+    url: $TELEMETRY_INFLUXDB_URL
+    secureJsonData:
+      token: $TELEMETRY_INFLUXDB_TOKEN
+    jsonData:
+      version: Flux
+      organization: $TELEMETRY_INFLUXDB_ORG
+      defaultBucket: $TELEMETRY_INFLUXDB_BUCKET
+      tlsSkipVerify: true


### PR DESCRIPTION
Include the grafana dashboards code and deployment.

Besides that, the Github actions pipeline is changed to create the custom grafana container, with the datasources and dashboards included, so we don't need to mount them externally in AWS ECS (which, by the way, I didn't achieve to do...)