### PR TITLE
Reduce desired container count to 1

### DIFF
--- a/deployment/modules/application_ecs/main.tf
+++ b/deployment/modules/application_ecs/main.tf
@@ -342,7 +342,7 @@ resource "aws_ecs_service" "main" {
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.main.arn
 
-  desired_count                      = 2
+  desired_count                      = 1
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   launch_type                        = "FARGATE"


### PR DESCRIPTION
In order to make the usage a bit simpler (specially in the grafana container, where we don't have any shared storage to store the password).